### PR TITLE
Command injection fix in Episode #182

### DIFF
--- a/episode-182/cropper/lib/paperclip_processors/cropper.rb
+++ b/episode-182/cropper/lib/paperclip_processors/cropper.rb
@@ -11,7 +11,7 @@ module Paperclip
     def crop_command
       target = @attachment.instance
       if target.cropping?
-        " -crop '#{target.crop_w}x#{target.crop_h}+#{target.crop_x}+#{target.crop_y}'"
+        " -crop '#{target.crop_w.to_i}x#{target.crop_h.to_i}+#{target.crop_x.to_i}+#{target.crop_y.to_i}'"
       end
     end
   end


### PR DESCRIPTION
In Episode #182 Cropping Images there is a remote command injection vulnerability as expounded by [iblue](http://railscasts.com/episodes/182-cropping-images?view=comments).

This commit fixes the vulnerability by adding `to_i` to the arguments.
