### PR TITLE
Twitter response structure changed .. user_info becomes info

### DIFF
--- a/episode-241/blog/app/models/user.rb
+++ b/episode-241/blog/app/models/user.rb
@@ -3,7 +3,7 @@ class User < ActiveRecord::Base
     create! do |user|
       user.provider = auth["provider"]
       user.uid = auth["uid"]
-      user.name = auth["user_info"]["name"]
+      user.name = auth["info"]["name"]
     end
   end
 end


### PR DESCRIPTION
Hey Ryan .. Lovely episode and thanks a ton for it .. The twitter response structure has changed and as the omniauth-oauth gem gobbles up the app errors, its pretty difficult for people to debug them.
oauth['user_info']['name'] is now oauth['info']['name']
